### PR TITLE
fix affectation rangChefLieu 

### DIFF
--- a/build/cog.js
+++ b/build/cog.js
@@ -167,7 +167,7 @@ async function extractCommunes(communesPath, mouvementsCommunesPath, arrondissem
       commune.departement = row.DEP
       commune.region = row.REG
       commune.type = 'commune-actuelle'
-      commune.rangChefLieu = getRangChefLieu(row.com, chefsLieuxArrondissement, chefsLieuxDepartement, chefsLieuxRegion)
+      commune.rangChefLieu = getRangChefLieu(row.COM, chefsLieuxArrondissement, chefsLieuxDepartement, chefsLieuxRegion)
       commune.anciensCodes = anciensCodesIndex[row.COM]
     }
 


### PR DESCRIPTION
Cet PR rétablit la détermination du rang de la commune.

### bug : 
 toutes les communes avait la valeur 0.
### après : 
ont une valeur ente 0,2,3,4, suivant leur correspondance avec les chefs lieux de région, de département, d'arrondissement.

## exemple
Limoges, chef lieu de la Haute-Vienne (département 87)
```json
 {
    code: '87085',
    nom: 'Limoges',
    typeLiaison: 0,
    zone: 'metro',
    arrondissement: '872',
    departement: '87',
    region: '75',
    type: 'commune-actuelle',
    rangChefLieu: 3,
    anciensCodes: [ '87010' ],
    siren: '218708501',
    codesPostaux: [ '87000', '87100', '87280' ],
    population: 129754
  }
````